### PR TITLE
Fix HttpClient reusage between instances of PexelsClient

### DIFF
--- a/PexelsNet/PexelsClient.cs
+++ b/PexelsNet/PexelsClient.cs
@@ -7,26 +7,25 @@ namespace PexelsNet
 {
     public class PexelsClient
     {
-        private readonly string _apiKey;
         private const string BaseUrl = "http://api.pexels.com/v1/";
 
-        private static readonly HttpClient Client = new HttpClient();
+        private readonly HttpClient _client = new HttpClient();
 
         public PexelsClient(string apiKey)
         {
-            Client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", apiKey);
+            _client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", apiKey);
         }
 
         public async Task<Page> SearchAsync(string query, int page = 1, int perPage = 15)
         {
-            HttpResponseMessage response = await Client.GetAsync(BaseUrl + "search?query=" + Uri.EscapeDataString(query) + "&per_page=" + perPage + "&page=" + page).ConfigureAwait(false);
+            HttpResponseMessage response = await _client.GetAsync(BaseUrl + "search?query=" + Uri.EscapeDataString(query) + "&per_page=" + perPage + "&page=" + page).ConfigureAwait(false);
 
             return await GetResultAsync(response).ConfigureAwait(false);
         }
 
         public async Task<Page> PopularAsync(int page = 1, int perPage = 15)
         {
-            HttpResponseMessage response = await Client.GetAsync(BaseUrl + "popular?per_page=" + perPage + "&page=" + page).ConfigureAwait(false);
+            HttpResponseMessage response = await _client.GetAsync(BaseUrl + "popular?per_page=" + perPage + "&page=" + page).ConfigureAwait(false);
 
             return await GetResultAsync(response).ConfigureAwait(false);
         }

--- a/PexelsNet/Properties/AssemblyInfo.cs
+++ b/PexelsNet/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.0.0")]
-[assembly: AssemblyFileVersion("2.3.0.0")]
+[assembly: AssemblyVersion("2.3.1.0")]
+[assembly: AssemblyFileVersion("2.3.1.0")]


### PR DESCRIPTION
Reusing the HttpClient does not allow to have different credentials between instances, plus the api keys are concatted together when calling TryAddWithoutValidation multiple times.